### PR TITLE
support postgresql v11-16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-11, macos-13, windows-latest]
-        postgresql_version: [10, 11, 12, 14, 15, 16]
+        postgresql_version: [11, 12, 14, 15, 16]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-11, macos-13, windows-latest]
-        postgresql_version: [10, 11, 12, 14, 15]
+        postgresql_version: [10, 11, 12, 14, 15, 16]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This Github action installs PostgreSQL on the GitHub actions runner and verifies
       - name: Setup PostgreSQL
         uses: tj-actions/install-postgresql@v2
         with:
-          postgresql-version: 15
+          postgresql-version: 16
 ```
 
 > NOTE: This updates the installed PostgreSQL version with the specified version and updates the PATH.
@@ -28,7 +28,7 @@ This Github action installs PostgreSQL on the GitHub actions runner and verifies
 
 |                                         INPUT                                          |  TYPE  | REQUIRED | DEFAULT |          DESCRIPTION          |
 |----------------------------------------------------------------------------------------|--------|----------|---------|-------------------------------|
-| <a name="input_postgresql-version"></a>[postgresql-version](#input_postgresql-version) | string |   true   |         | Version of PostgreSQL. e.g 15 |
+| <a name="input_postgresql-version"></a>[postgresql-version](#input_postgresql-version) | string |   true   |         | Version of PostgreSQL. e.g 16 |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: Install PostgreSQL on the GitHub actions runner and verify the inst
 author: tj-actions
 inputs:
   postgresql-version: 
-    description: 'Version of PostgreSQL. e.g 15'
+    description: 'Version of PostgreSQL. e.g 16'
     required: true
 
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 # Check if the input is between 11 and 16 (inclusive)
 if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
-    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 16 (inclusive)."
+    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 11 and 16 (inclusive)."
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if ! [[ "$INPUT_POSTGRESQL_VERSION" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-# Check if the input is between 10 and 16 (inclusive)
-if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
-    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 16 (inclusive)."
+# Check if the input is between 11 and 16 (inclusive)
+if (( INPUT_POSTGRESQL_VERSION < 11 || INPUT_POSTGRESQL_VERSION > 16 )); then
+    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 11 and 16 (inclusive)."
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ if ! [[ "$INPUT_POSTGRESQL_VERSION" =~ ^[0-9]+$ ]]; then
 fi
 
 # Check if the input is between 11 and 16 (inclusive)
-if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
+if (( INPUT_POSTGRESQL_VERSION < 11 || INPUT_POSTGRESQL_VERSION > 16 )); then
     echo "Error: $INPUT_POSTGRESQL_VERSION is not between 11 and 16 (inclusive)."
     exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if ! [[ "$INPUT_POSTGRESQL_VERSION" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-# Check if the input is between 10 and 16 (inclusive)
+# Check if the input is between 11 and 16 (inclusive)
 if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
     echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 16 (inclusive)."
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if ! [[ "$INPUT_POSTGRESQL_VERSION" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-# Check if the input is between 10 and 15 (inclusive)
-if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 15 )); then
-    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 15 (inclusive)."
+# Check if the input is between 10 and 16 (inclusive)
+if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
+    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 16 (inclusive)."
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ if ! [[ "$INPUT_POSTGRESQL_VERSION" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-# Check if the input is between 11 and 16 (inclusive)
-if (( INPUT_POSTGRESQL_VERSION < 11 || INPUT_POSTGRESQL_VERSION > 16 )); then
-    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 11 and 16 (inclusive)."
+# Check if the input is between 10 and 16 (inclusive)
+if (( INPUT_POSTGRESQL_VERSION < 10 || INPUT_POSTGRESQL_VERSION > 16 )); then
+    echo "Error: $INPUT_POSTGRESQL_VERSION is not between 10 and 16 (inclusive)."
     exit 1
 fi
 


### PR DESCRIPTION
PostgreSQL v16 was [publicly released](https://www.postgresql.org/about/news/postgresql-16-released-2715/) this last September, but this action (and therefore by extension tj-actions/pg-dump) hard-caps users to installing v15 at the highest.

This PR modernizes that limitation, allowing users to install postgresql v16.

It also causes the tests to _stop_ installing postgresql v10 (though it still allows for users to specify v10 for backward-compatibility purposes), because the homebrew-based installation tests on macOS now fail when attempting to install v10, with this message:
```
Error: postgresql@10 has been disabled because it is not supported upstream!
```

I believe this change should prompt a new version release, or at least a re-release of v2, so that other actions (like tj-actions/pg-dump) can be updated to work with v16 properly.